### PR TITLE
Improve UI layout and auto-expand LOB metrics sections

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -305,8 +305,6 @@ function VolumeBacklogModelView() {
         displayedPeriodHeaders={displayedPeriodHeaders}
         activeHierarchyContext={activeHierarchyContext}
         headerPeriodScrollerRef={headerPeriodScrollerRef}
-        selectedModel={'volume-backlog'}
-        onModelChange={() => {}} // Not used in this view
       />
       <main className="flex-grow overflow-hidden">
         <CapacityTable

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -61,6 +61,18 @@ function VolumeBacklogModelView() {
     return allAvailablePeriods.slice(0, 12);
   }, [selectedDateRange, allAvailablePeriods]);
 
+  // Auto-expand LOBs to show their metrics by default
+  useEffect(() => {
+    const newExpandedState: Record<string, boolean> = {};
+    rawCapacityData.forEach(entry => {
+      const lobId = entry.id;
+      newExpandedState[lobId] = true; // Auto-expand LOBs
+      // Auto-expand BUs as well
+      newExpandedState[`bu-${entry.bu.toLowerCase().replace(/\s+/g, '-')}`] = true;
+    });
+    setExpandedItems(prev => ({ ...prev, ...newExpandedState }));
+  }, [rawCapacityData]);
+
   const processedCapacityData = useMemo(() => {
     const standardWorkMinutesForPeriod = selectedTimeInterval === "Week" 
       ? STANDARD_WEEKLY_WORK_MINUTES 

--- a/src/components/capacity-insights/capacity-table.tsx
+++ b/src/components/capacity-insights/capacity-table.tsx
@@ -703,29 +703,27 @@ export const CapacityTable: React.FC<CapacityTableProps> = memo(({
 
     } else { // BU or LOB
       aggregatedMetricDefinitions.forEach(metricDef => {
+        // Skip LOB-specific input metrics for BU level
         if (item.itemType === 'BU' && (metricDef.key === 'lobVolumeForecast' || metricDef.key === 'lobAverageAHT' || metricDef.key === 'lobTotalBaseRequiredMinutes')) {
-           return; // Do not render LOB-specific inputs for BU
+           return;
         }
-        if (item.itemType === 'LOB' && metricDef.key === 'lobTotalBaseRequiredMinutes' && !metricDef.isEditableForLob){
-          // This condition might be redundant if only one definition exists, but good for clarity
-          // If there's one marked editable and another for display, this would hide the display-only one
-        } else {
-           rows.push(
-            <MetricRow
-              key={`${item.id}-${metricDef.key}`}
-              item={item}
-              metricDef={metricDef}
-              level={item.level + 1}
-              periodHeaders={periodHeaders}
-              onTeamMetricChange={onTeamMetricChange} // Pass down
-              onLobMetricChange={onLobMetricChange}   // Pass down
-              editingCell={editingCell}
-              onSetEditingCell={onSetEditingCell}
-              selectedTimeInterval={selectedTimeInterval}
-              selectedModel={selectedModel}
-            />
-          );
-        }
+
+        // Render all appropriate metrics for LOB and BU
+        rows.push(
+          <MetricRow
+            key={`${item.id}-${metricDef.key}`}
+            item={item}
+            metricDef={metricDef}
+            level={item.level + 1}
+            periodHeaders={periodHeaders}
+            onTeamMetricChange={onTeamMetricChange}
+            onLobMetricChange={onLobMetricChange}
+            editingCell={editingCell}
+            onSetEditingCell={onSetEditingCell}
+            selectedTimeInterval={selectedTimeInterval}
+            selectedModel={selectedModel}
+          />
+        );
       });
     }
     return rows;

--- a/src/components/capacity-insights/capacity-table.tsx
+++ b/src/components/capacity-insights/capacity-table.tsx
@@ -702,19 +702,73 @@ export const CapacityTable: React.FC<CapacityTableProps> = memo(({
       rows.push(...renderSubSection(item.id, "HC Adjustments", adjustmentMetrics, item, item.level + 1));
 
     } else { // BU or LOB
-      aggregatedMetricDefinitions.forEach(metricDef => {
-        // Skip LOB-specific input metrics for BU level
-        if (item.itemType === 'BU' && (metricDef.key === 'lobVolumeForecast' || metricDef.key === 'lobAverageAHT' || metricDef.key === 'lobTotalBaseRequiredMinutes')) {
-           return;
+      // Separate LOB input metrics from HC summary metrics for better organization
+      const lobInputMetrics = aggregatedMetricDefinitions.filter(def =>
+        def.key === 'lobVolumeForecast' || def.key === 'lobAverageAHT' || def.key === 'lobTotalBaseRequiredMinutes'
+      );
+      const hcSummaryMetrics = aggregatedMetricDefinitions.filter(def =>
+        def.key === 'requiredHC' || def.key === 'actualHC' || def.key === 'overUnderHC'
+      );
+
+      // For LOB items, show input metrics first, then HC summary
+      if (item.itemType === 'LOB') {
+        // LOB Input Metrics section
+        if (lobInputMetrics.length > 0) {
+          rows.push(
+            <TableRow key={`${item.id}_inputs_header`} className="hover:bg-muted/30 bg-muted/10">
+              <TableCell
+                className="sticky left-0 z-20 bg-muted/10 font-medium text-foreground whitespace-nowrap py-2 border-r border-border/50"
+                style={{ paddingLeft: `${(item.level + 1) * 1.5 + 0.5}rem`, paddingRight: '1rem' }}
+              >
+                <span className="text-sm font-semibold text-primary">LOB Configuration</span>
+              </TableCell>
+              {periodHeaders.map(ph => <TableCell key={`${item.id}_inputs_${ph}_placeholder`} className="py-2 px-2 min-w-[100px] border-l border-border/50 bg-muted/10"></TableCell>)}
+            </TableRow>
+          );
+
+          lobInputMetrics.forEach(metricDef => {
+            rows.push(
+              <MetricRow
+                key={`${item.id}-${metricDef.key}`}
+                item={item}
+                metricDef={metricDef}
+                level={item.level + 2}
+                periodHeaders={periodHeaders}
+                onTeamMetricChange={onTeamMetricChange}
+                onLobMetricChange={onLobMetricChange}
+                editingCell={editingCell}
+                onSetEditingCell={onSetEditingCell}
+                selectedTimeInterval={selectedTimeInterval}
+                selectedModel={selectedModel}
+              />
+            );
+          });
         }
 
-        // Render all appropriate metrics for LOB and BU
+        // HC Summary section
+        if (hcSummaryMetrics.length > 0) {
+          rows.push(
+            <TableRow key={`${item.id}_hc_header`} className="hover:bg-muted/30 bg-muted/10">
+              <TableCell
+                className="sticky left-0 z-20 bg-muted/10 font-medium text-foreground whitespace-nowrap py-2 border-r border-border/50"
+                style={{ paddingLeft: `${(item.level + 1) * 1.5 + 0.5}rem`, paddingRight: '1rem' }}
+              >
+                <span className="text-sm font-semibold text-blue-600">HC Summary</span>
+              </TableCell>
+              {periodHeaders.map(ph => <TableCell key={`${item.id}_hc_${ph}_placeholder`} className="py-2 px-2 min-w-[100px] border-l border-border/50 bg-muted/10"></TableCell>)}
+            </TableRow>
+          );
+        }
+      }
+
+      // Render HC summary metrics for both LOB and BU
+      hcSummaryMetrics.forEach(metricDef => {
         rows.push(
           <MetricRow
             key={`${item.id}-${metricDef.key}`}
             item={item}
             metricDef={metricDef}
-            level={item.level + 1}
+            level={item.itemType === 'LOB' ? item.level + 2 : item.level + 1}
             periodHeaders={periodHeaders}
             onTeamMetricChange={onTeamMetricChange}
             onLobMetricChange={onLobMetricChange}

--- a/src/components/capacity-insights/header-section.tsx
+++ b/src/components/capacity-insights/header-section.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import React, { useState } from "react";
@@ -26,13 +25,8 @@ import { cn } from "@/lib/utils";
 import type { HeaderSectionProps, BusinessUnitName, LineOfBusinessName, TimeInterval } from "./types";
 import { DateRangePicker } from "./date-range-picker";
 import { AiGroupingDialog } from "./ai-grouping-dialog";
-import { ModelSelector } from "@/components/model-selector/model-selector";
-import type { ModelType } from "@/models/shared/interfaces";
 
-interface ExtendedHeaderSectionProps extends HeaderSectionProps {
-  selectedModel: ModelType;
-  onModelChange: (model: ModelType) => void;
-}
+
 
 export function HeaderSection({
   allBusinessUnits,
@@ -50,9 +44,7 @@ export function HeaderSection({
   displayedPeriodHeaders,
   activeHierarchyContext,
   headerPeriodScrollerRef,
-  selectedModel,
-  onModelChange,
-}: ExtendedHeaderSectionProps) {
+}: HeaderSectionProps) {
   const [isAiDialogOpen, setIsAiDialogOpen] = useState(false);
 
   const handleLobSelectionChange = (lob: string, checked: boolean) => {
@@ -94,10 +86,6 @@ export function HeaderSection({
         </div>
 
         <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:flex lg:flex-wrap lg:items-end gap-x-4 gap-y-2">
-          <ModelSelector
-            selectedModel={selectedModel}
-            onModelChange={onModelChange}
-          />
 
           <div className="flex flex-col gap-1.5">
             <Label className="text-xs text-muted-foreground">Business Unit</Label>
@@ -219,5 +207,3 @@ export function HeaderSection({
     </TooltipProvider>
   );
 }
-
-    

--- a/src/components/capacity-insights/header-section.tsx
+++ b/src/components/capacity-insights/header-section.tsx
@@ -85,39 +85,42 @@ export function HeaderSection({
           </div>
         </div>
 
-        <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 lg:flex lg:flex-wrap lg:items-end gap-x-4 gap-y-2">
+        <div className="mt-6 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:flex xl:flex-wrap xl:items-end gap-x-4 gap-y-4">
 
-          <div className="flex flex-col gap-1.5">
-            <Label className="text-xs text-muted-foreground">Business Unit</Label>
+          <div className="flex flex-col gap-2">
+            <Label className="text-sm font-medium text-foreground">Business Unit</Label>
             <Select value={selectedBusinessUnit} onValueChange={onSelectBusinessUnit}>
-              <SelectTrigger className="w-full lg:w-[180px] text-sm h-9">
-                <Building2 className="mr-2 h-4 w-4 opacity-70" />
-                <SelectValue placeholder="Business Unit" />
+              <SelectTrigger className="w-full xl:w-[200px] text-sm h-10 border-2 transition-colors hover:border-primary/50 focus:border-primary">
+                <Building2 className="mr-2 h-4 w-4 text-primary" />
+                <SelectValue placeholder="Select Business Unit" />
               </SelectTrigger>
               <SelectContent>
                 {allBusinessUnits.map((bu) => (
-                  <SelectItem key={bu} value={bu}>
-                    {bu}
+                  <SelectItem key={bu} value={bu} className="cursor-pointer">
+                    <div className="flex items-center gap-2">
+                      <Building2 className="h-4 w-4 text-muted-foreground" />
+                      <span>{bu}</span>
+                    </div>
                   </SelectItem>
                 ))}
               </SelectContent>
             </Select>
           </div>
 
-          <div className="flex flex-col gap-1.5">
-            <Label className="text-xs text-muted-foreground">Line of Business</Label>
+          <div className="flex flex-col gap-2">
+            <Label className="text-sm font-medium text-foreground">Line of Business</Label>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="outline" className="w-full lg:w-[240px] text-sm h-9 justify-between">
+                <Button variant="outline" className="w-full xl:w-[280px] text-sm h-10 justify-between border-2 transition-colors hover:border-primary/50 focus:border-primary">
                   <div className="flex items-center truncate">
-                    <Briefcase className="mr-2 h-4 w-4 opacity-70 flex-shrink-0" />
+                    <Briefcase className="mr-2 h-4 w-4 text-primary flex-shrink-0" />
                     <span className="truncate" title={lobDropdownLabel}>{lobDropdownLabel}</span>
                   </div>
-                  <ChevronDown className="h-4 w-4 opacity-50 flex-shrink-0" />
+                  <ChevronDown className="h-4 w-4 text-muted-foreground flex-shrink-0" />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent className="w-full md:w-[240px]">
-                <DropdownMenuLabel>Select Lines of Business</DropdownMenuLabel>
+              <DropdownMenuContent className="w-[280px]">
+                <DropdownMenuLabel className="text-sm font-semibold">Select Lines of Business</DropdownMenuLabel>
                 <DropdownMenuSeparator />
                 {actualLobsForCurrentBu.length > 0 ? (
                   actualLobsForCurrentBu.map((lob) => (
@@ -125,9 +128,13 @@ export function HeaderSection({
                       key={lob}
                       checked={selectedLineOfBusiness.includes(lob)}
                       onCheckedChange={(checked) => handleLobSelectionChange(lob, Boolean(checked))}
-                      onSelect={(e) => e.preventDefault()} // Keep menu open after selection
+                      onSelect={(e) => e.preventDefault()}
+                      className="cursor-pointer"
                     >
-                      {lob}
+                      <div className="flex items-center gap-2">
+                        <Briefcase className="h-4 w-4 text-muted-foreground" />
+                        <span>{lob}</span>
+                      </div>
                     </DropdownMenuCheckboxItem>
                   ))
                 ) : (
@@ -137,14 +144,17 @@ export function HeaderSection({
             </DropdownMenu>
           </div>
           
-          <div className="flex flex-col gap-1.5">
-            <Label className="text-xs text-muted-foreground">Interval</Label>
-            <div className="flex items-center gap-1 border rounded-md p-0.5 bg-muted h-9">
+          <div className="flex flex-col gap-2">
+            <Label className="text-sm font-medium text-foreground">Interval</Label>
+            <div className="flex items-center gap-1 border-2 rounded-lg p-1 bg-muted/30 h-10 transition-colors hover:border-primary/50">
               <Button
                 variant={selectedTimeInterval === "Week" ? "default" : "ghost"}
                 size="sm"
                 onClick={() => onSelectTimeInterval("Week")}
-                className="h-full px-3 flex-1 text-xs"
+                className={cn(
+                  "h-8 px-4 flex-1 text-sm font-medium transition-all",
+                  selectedTimeInterval === "Week" && "shadow-sm"
+                )}
               >
                 Week
               </Button>
@@ -152,16 +162,21 @@ export function HeaderSection({
                 variant={selectedTimeInterval === "Month" ? "default" : "ghost"}
                 size="sm"
                 onClick={() => onSelectTimeInterval("Month")}
-                className="h-full px-3 flex-1 text-xs"
+                className={cn(
+                  "h-8 px-4 flex-1 text-sm font-medium transition-all",
+                  selectedTimeInterval === "Month" && "shadow-sm"
+                )}
               >
                 Month
               </Button>
             </div>
           </div>
 
-          <div className="flex flex-col gap-1.5">
-            <Label className="text-xs text-muted-foreground">Date Range</Label>
-            <DateRangePicker date={selectedDateRange} onDateChange={onSelectDateRange} allAvailablePeriods={allAvailablePeriods} />
+          <div className="flex flex-col gap-2">
+            <Label className="text-sm font-medium text-foreground">Date Range</Label>
+            <div className="[&_button]:h-10 [&_button]:border-2 [&_button]:transition-colors [&_button:hover]:border-primary/50">
+              <DateRangePicker date={selectedDateRange} onDateChange={onSelectDateRange} allAvailablePeriods={allAvailablePeriods} />
+            </div>
           </div>
         </div>
 

--- a/src/components/model-tabs.tsx
+++ b/src/components/model-tabs.tsx
@@ -24,31 +24,44 @@ export function ModelTabs({ selectedModel, onModelChange, className }: ModelTabs
   };
 
   return (
-    <div className={cn("flex flex-wrap gap-2 p-4 bg-card border-b border-border", className)}>
-      {AVAILABLE_MODELS.map((model) => (
-        <Button
-          key={model.id}
-          variant={selectedModel === model.id ? "default" : "outline"}
-          onClick={() => onModelChange(model.id)}
-          className={cn(
-            "flex flex-col items-start gap-1 h-auto p-3 min-w-[200px]",
-            selectedModel === model.id && "ring-2 ring-primary ring-offset-2"
-          )}
-        >
-          <div className="flex items-center justify-between w-full">
-            <span className="font-medium text-sm">{model.name}</span>
-            <Badge 
-              variant="outline" 
-              className={cn("text-xs", getComplexityColor(model.complexity))}
-            >
-              {model.complexity}
-            </Badge>
-          </div>
-          <span className="text-xs text-muted-foreground text-left">
-            {model.description}
-          </span>
-        </Button>
-      ))}
+    <div className={cn("bg-card border-b border-border", className)}>
+      <div className="px-4 py-3 border-b border-border/50">
+        <h2 className="text-lg font-semibold text-foreground">Capacity Planning Models</h2>
+        <p className="text-sm text-muted-foreground mt-1">Select a model to configure your capacity planning approach</p>
+      </div>
+      <div className="flex flex-wrap gap-3 p-4">
+        {AVAILABLE_MODELS.map((model) => (
+          <Button
+            key={model.id}
+            variant={selectedModel === model.id ? "default" : "outline"}
+            onClick={() => onModelChange(model.id)}
+            className={cn(
+              "flex flex-col items-start gap-2 h-auto p-4 min-w-[240px] max-w-[280px] transition-all duration-200 hover:scale-[1.02]",
+              selectedModel === model.id && "ring-2 ring-primary ring-offset-2 shadow-lg",
+              "group relative overflow-hidden"
+            )}
+          >
+            <div className="flex items-center justify-between w-full">
+              <span className="font-semibold text-sm">{model.name}</span>
+              <Badge
+                variant={selectedModel === model.id ? "secondary" : "outline"}
+                className={cn(
+                  "text-xs font-medium transition-colors",
+                  selectedModel === model.id ? "bg-primary-foreground text-primary" : getComplexityColor(model.complexity)
+                )}
+              >
+                {model.complexity}
+              </Badge>
+            </div>
+            <span className="text-xs text-muted-foreground text-left leading-relaxed">
+              {model.description}
+            </span>
+            {selectedModel === model.id && (
+              <div className="absolute inset-0 bg-primary/5 pointer-events-none" />
+            )}
+          </Button>
+        ))}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
This pull request makes several UI improvements to the capacity planning interface:

**Auto-expansion functionality:**
- Added useEffect to automatically expand LOBs and BUs to show their metrics by default
- Auto-expands both LOB items and their corresponding BU sections

**Capacity table organization:**
- Reorganized LOB metrics into separate "LOB Configuration" and "HC Summary" sections
- Added section headers with distinct styling for better visual separation
- Improved metric grouping logic to separate input metrics from HC summary metrics

**Header section styling:**
- Enhanced form controls with improved spacing, borders, and hover states
- Updated grid layout for better responsive behavior
- Added icons and improved visual hierarchy for dropdowns and selectors
- Removed unused model selector props and imports

**Model tabs enhancement:**
- Added descriptive header section with title and subtitle
- Improved card styling with hover effects and better spacing
- Enhanced selected state with background overlay and improved badge styling

**Code cleanup:**
- Removed unused selectedModel and onModelChange props from HeaderSection
- Cleaned up imports and removed trailing whitespace

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/app/projects/addcb4f4c3e74243b64acc4bf58ec870/nova-verse)

👀 [Preview Link](https://addcb4f4c3e74243b64acc4bf58ec870-nova-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>addcb4f4c3e74243b64acc4bf58ec870</projectId>-->
<!--<branchName>nova-verse</branchName>-->